### PR TITLE
Add Terraform for AWS with EC2

### DIFF
--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.74.0"
+  hashes = [
+    "h1:y9b9LluBQGrZHURGY1Xmrhb+zQ6qRit3oqFSLijkGe0=",
+    "zh:00767509c13c0d1c7ad6af702c6942e6572aa6d529b40a00baacc0e73faafea2",
+    "zh:03aafdc903ad49c2eda03889f927f44212674c50e475a9c6298850381319eec2",
+    "zh:2de8a6a97b180f909d652f215125aa4683e99db15fcf3b28d62e3d542f875ed6",
+    "zh:3ac29ebc3af99028f4230a79f56606a0c2954b68767bd749b921a76eb4f3bd30",
+    "zh:50add2e2d118a15a644360eabc5a34cec59f2560b491f8fabf9c52ab83ca7b09",
+    "zh:85dd8e81910ab79f841a4a595fdd8ac358fbfe460956144afb0be3d81f91fe10",
+    "zh:895de83d0f0941fde31bfc53fa6b1ea276901f006bec221bbdee4771a04f3693",
+    "zh:a15c9724aac52d1ba5001d2d83e42843099b52b1638ea29d84e20be0f45fa4f1",
+    "zh:c982a64463bd73e9bff2589de214b1de0a571438d9015001f9eae45cfc3a2559",
+    "zh:e9ef973c18078324e43213ea1252c12b9441e566bf054ddfdbff5dd62f3035d9",
+    "zh:f297e705b0f339c8baa27ae70db5df9aa6578adfe1ea3d2ba8edc186512464eb",
+  ]
+}

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,22 @@
+# Deploy to AWS with Terraform
+
+First set up the AWS keys in your environment.
+
+When you run these commands it will prompt you for a Github username. From this it downloads the public keys for the user and adds them as the ssh user for the EC2 instance.
+
+```bash
+terraform init
+terraform apply
+```
+
+Once you are finished you can destroy everything with `terraform destroy`
+
+## Example output
+
+```
+Outputs:
+
+health_check_url = "http://44.202.90.183:5060/health-check"
+ip_addresses_url = "http://44.202.90.183:8082/ip-addresses"
+ssh_command = "ssh ubuntu@44.202.90.183"
+```

--- a/infrastructure/install.sh
+++ b/infrastructure/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+export PATH=/usr/local/bin:$PATH;
+
+curl https://github.com/${github_user}.keys >> /home/ubuntu/.ssh/authorized_keys
+
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+apt-get update
+apt-get install -y docker-ce
+usermod -aG docker ubuntu
+
+docker pull sentrypeer/sentrypeer
+docker run -d -p 5060:5060 -p 8082:8082 sentrypeer/sentrypeer:latest

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,67 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "github_user" {
+  type = string
+  description = "Use this users public keys for ssh"
+}
+
+resource "aws_instance" "sentypeer_instance" {
+  ami           = "ami-04169656fea786776"
+  instance_type = "t2.nano"
+  user_data     = templatefile("install.sh", { github_user = var.github_user})
+  tags = {
+    Name  = "SentryPeer"
+    Origin = "Terraform"
+  }
+
+  vpc_security_group_ids = [aws_security_group.web_sg.id]
+}
+
+resource "aws_security_group" "web_sg" {
+  name = "sentrypeer-sg"
+  ingress {
+    from_port   = 8082
+    to_port     = 8082
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 5060
+    to_port     = 5060
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+output "health_check_url" {
+  description = "URL for the health check"
+  value       = "http://${aws_instance.sentypeer_instance.public_ip}:5060/health-check"
+}
+
+output "ip_addresses_url" {
+  description = "URL for the ip addresses"
+  value       = "http://${aws_instance.sentypeer_instance.public_ip}:8082/ip-addresses"
+}
+
+output "ssh_command" {
+  description = "Log into the server with"
+  value       = "ssh ubuntu@${aws_instance.sentypeer_instance.public_ip}"
+}
+


### PR DESCRIPTION
Adds an AWS Terraform provider for #12 

In this case, it runs via EC2 rather than ECS. The README attached has instructions on how to run it.