### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Debian or Fedora packages are always available from the release page for the cur
 You can install SentryPeer from [our Ubuntu PPD](https://launchpad.net/~gavinhenry/+archive/ubuntu/sentrypeer) which
 is currently for Ubuntu 20 LTS (Focal Fossa):
 
+    sudo apt install software-properties-common
     sudo add-apt-repository ppa:gavinhenry/sentrypeer
     sudo apt-get update
 


### PR DESCRIPTION
Added `sudo apt install software-properties-common` so that the apt-add-repository tool is available for use when adding the repro.

# Pull Request Template

## Description

Added `sudo apt install software-properties-common` so that the apt-add-repository tool is available for use when adding the repro.

Fixes # 

Found the base install of ubuntu 20.04 LTS was lacking this step prior to allowing to deploy the apt-add-repository command. 

## Type of change

Minor change to documentation 

## How Has This Been Tested?

- Tested on an LCX container of base install of Ubuntu 
- Tested on a minimal install of Ubuntu from a network ISO. 
